### PR TITLE
Rewrite keybindings to use <Plug>

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Example:
 
 #### Special Bindings
 
-A 'quick' ClangFormat binding is provided via `g:fmtv_clang_format_line_key`. This works on the current line alone. Its default mapping is `<C-K>k`, which is designed to emulate vim's `c -> cc`, `d -> dd` line-wise operations.
+A 'quick' ClangFormat binding is provided via `<Plug>FormativeLine`. This works on the current line alone. Its default mapping is `<C-K>k`, which is designed to emulate vim's `c -> cc`, `d -> dd` line-wise operations.
 
-There's also a binding for invoking clang-format on the entirety of the current file, and is great for doing a lot of formatting in one go. Its default mapping is `<C-K>u`, and is modified by setting `g:fmtv_clang_format_file_key` to your own preferred key combination.
+There's also a binding for invoking clang-format on the entirety of the current file, and is great for doing a lot of formatting in one go. Its default mapping is `<C-K>u`, and is modified by setting `<Plug>FormativeFile` to your own preferred key combination.
 
 In summary, here are the additional, special, reconfigurable bindings:
 
@@ -65,16 +65,20 @@ Don't forget to update the help with: `:helptags`
 
 ## Customisation
 
-You will probably need to override the default path to your `clang-format.py` script. In your `.vimrc`, add the following line:
+You will probably need to override the default path to your `clang-format.py` script. The default assumes it lives in your `.vim` directory, i.e. `~/.vim/clang-format.py`. To override this, add the following line to your `.vimrc`:
 
     let g:fmtv_clang_format_py = '/path/to/my/clang-format.py'
 
-You can remove or override the default key bindings, too. Any of the following examples can be added to your `.vimrc`.
+You can remove or override the default key bindings, too. By default the plugin will map `<C-K>` to the plugin features. You can prevent the default mappings by setting `g:fmtv_no_mappings` in your `.vimrc`:
 
-    let g:fmtv_clang_format_nor_key  = MyKeyBinding 
-    let g:fmtv_clang_format_vis_key  = MyKeyBinding 
-    let g:fmtv_clang_format_ins_key  = MyKeyBinding 
-    let g:fmtv_clang_format_line_key = MyKeyBinding 
-    let g:fmtv_clang_format_file_key = MyKeyBinding
+   let g:fmtv_no_mappings = 1
+
+Any of the mappings can be individually set or overridden in your `.vimrc`.
+
+    nmap MyKeyBinding <Plug>FormativeNor
+    vmap MyKeyBinding <Plug>FormativeVis
+    imap MyKeyBinding <Plug>FormativeIns
+    nmap MyKeyBinding <Plug>FormativeLine
+    nmap MyKeyBinding <Plug>FormativeFile
 
 Note: please read the help by typing `:help formative` in vim for more information.

--- a/autoload/formative.vim
+++ b/autoload/formative.vim
@@ -1,6 +1,6 @@
 " formative.vim - ClangFormat with text-objects
 " Author: Fraser Cormack <frasercrmck@gmail.com>
-" Version: 1.3
+" Version: 2.0
 " License: This file is placed in the public domain.
 " Source repository: https://github.com/frasercrmck/formative.vim
 

--- a/doc/formative.txt
+++ b/doc/formative.txt
@@ -23,7 +23,7 @@ Example:
     <C-K>k  (special) - clang-format the current line (quickly)
     <C-K>u  (special) - clang-format the whole file
 
-See |g:fmtv_clang_format_line_key| for an explanation of the '<C-K>k' usage.
+See |FormativeLine| for an explanation of the '<C-K>k' usage.
 
 ==============================================================================
 OPTIONS                                                      *formative-options*
@@ -31,29 +31,34 @@ OPTIONS                                                      *formative-options*
                                                         *g:fmtv_clang_format_py*
 Specifies the path to the clang-format.py script on your system.
 Default: `~/.vim/clang-format.py`. Example: >
-    let g:fmtv_clang_format_py = /path/to/my/clang-format.py
-
-<                                                   *g:fmtv_clang_format_nor_key*
-Specifies the key to invoke clang-format in |normal| mode. Default: `'<C-k>'`.
+    let g:fmtv_clang_format_py = '/path/to/my/clang-format.py'
+<
+                                                            *g:fmtv_no_mappings*
+Disables all default plugin mappings, individually documented below. Useful if
+the defaults (typically using <C-k>) would overwrite your own mappings.
 Example: >
-    let g:fmtv_clang_format_nor_key = '<leader>c'
-<                                                    *g:fmtv_clang_format_vis_key*
-Specifies the key to invoke clang-format in |visual| mode. Default: `'<C-k>'`.
+    let g:fmtv_no_mappings = 1
+<                                                               *FormativeNor*
+Invokes clang-format in |normal| mode. Default: `'<C-k>'`.
 Example: >
-    let g:fmtv_clang_format_vis_key = '<leader>c'
-<                                                    *g:fmtv_clang_format_ins_key*
-Specifies the key to invoke clang-format in |insert| mode. Default: `'<C-k>'`.
+    nmap <leader>c <Plug>FormativeNor
+<                                                               *FormativeVis*
+Invoke clang-format in |visual| mode. Default: `'<C-k>'`.
 Example: >
-    let g:fmtv_clang_format_ins_key = '<leader>c'
-<                                                   *g:fmtv_clang_format_line_key*
-Specifies the key to invoke clang-format in |normal| mode on the current line.
+    vmap <leader>c <Plug>FormativeVis
+<                                                               *FormativeIns*
+Invoke clang-format in |insert| mode. Default: `'<C-k>'`.
+Example: >
+    imap <leader>c <Plug>FormativeIns
+<                                                               *FormativeLine*
+Invokes clang-format in |normal| mode on the current line.
 Intended to model the functionality of |c| -> |cc|, |d| -> |dd|, etc.
 Default: `'<C-k>k'`. Example: >
-    let g:fmtv_clang_format_line_key = '<leader>cc'
-<                                                   *g:fmtv_clang_format_file_key*
-Specifies the key to invoke clang-format in |normal| mode on the current file.
+    nmap <leader>cc <Plug>FormativeLine
+<                                                               *FormativeFile*
+Invokes clang-format in |normal| mode on the current file.
 Default: `'<C-k>u'`. Example: >
-    let g:fmtv_clang_format_file_key = '<leader>d'
+    nmap <leader>d <Plug>FormativeFile
 <
 ==============================================================================
 LICENSE                                                     *formative-license*

--- a/plugin/formative.vim
+++ b/plugin/formative.vim
@@ -1,6 +1,6 @@
 " formative.vim - ClangFormat with text-objects
 " Author: Fraser Cormack <frasercrmck@gmail.com>
-" Version: 1.3
+" Version: 2.0
 " License: This file is placed in the public domain.
 " Source repository: https://github.com/frasercrmck/formative.vim
 
@@ -14,22 +14,18 @@ let g:loaded_formative = 1
 
 let g:fmtv_clang_format_py = get( g:, 'fmtv_clang_format_py', '~/.vim/clang-format.py')
 
-let g:fmtv_clang_format_nor_key  = get( g:, 'fmtv_clang_format_nor_key', '<C-k>')
-let g:fmtv_clang_format_vis_key  = get( g:, 'fmtv_clang_format_vis_key', '<C-k>')
-let g:fmtv_clang_format_ins_key  = get( g:, 'fmtv_clang_format_ins_key', '<C-k>')
-let g:fmtv_clang_format_line_key = get( g:, 'fmtv_clang_format_line_key', '<C-k>k')
-let g:fmtv_clang_format_file_key = get( g:, 'fmtv_clang_format_file_key', '<C-k>u')
+nnoremap <silent> <Plug>FormativeNor :<C-U>set opfunc=formative#ClangFormat<CR>g@
+nnoremap <silent> <Plug>FormativeLine :<C-U>call formative#ClangFormat('oneline')<CR>
+nnoremap <silent> <Plug>FormativeFile :<C-U>call formative#ClangFormat('file')<CR>
 
-execute "nnoremap <silent> " . g:fmtv_clang_format_nor_key .
-      \ " :<C-U>set opfunc=formative#ClangFormat<CR>g@"
-execute "nnoremap <silent> " . g:fmtv_clang_format_line_key .
-      \ " :<C-U>call formative#ClangFormat('oneline')<CR>"
-execute "nnoremap <silent> " . g:fmtv_clang_format_file_key .
-      \ " :<C-U>call formative#ClangFormat('file')<CR>"
+vnoremap <silent> <Plug>FormativeVis :<C-U>call formative#ClangFormat(visualmode(), 1)<CR>
+inoremap <silent> <Plug>FormativeIns <ESC>:<C-U>call formative#ClangFormat('oneline')<CR>a
 
-execute "vnoremap <silent> " . g:fmtv_clang_format_vis_key .
-      \ " :<C-U>call formative#ClangFormat(visualmode(), 1)<CR>"
+if !exists("g:fmtv_no_mappings") || ! g:fmtv_no_mappings
+  nmap <C-k> <Plug>FormativeNor
+  vmap <C-k> <Plug>FormativeVis
+  imap <C-k> <Plug>FormativeIns
 
-execute "inoremap <silent> " . g:fmtv_clang_format_ins_key .
-      \ " <ESC>:<C-U>call formative#ClangFormat('oneline')<CR>a"
-
+  nmap <C-k>k <Plug>FormativeLine
+  nmap <C-k>u <Plug>FormativeFile
+endif


### PR DESCRIPTION
The core functionality is now provided through a set of `<Plug>`s:

    <Plug>FmtNor  -- normal mode
    <Plug>FmtVis  -- visual mode
    <Plug>FmtIns  -- insert mode
    <Plug>FmtLine -- line
    <Plug>FmtFile -- file

These `<Plug>`s are now the target of the default keybindings, which can
be overridden like normal mappings. This allows for more flexibility for
user mappings than relying on global variables.

Updated help documentation and README accordingly.